### PR TITLE
Removed redundant code, refactored test

### DIFF
--- a/internal/lockclient/simple_client.go
+++ b/internal/lockclient/simple_client.go
@@ -10,27 +10,11 @@ import (
 	"github.com/SystemBuilders/LocKey/internal/lockservice"
 )
 
-var _ Config = (*SimpleConfig)(nil)
-
-// SimpleConfig implements Config.
-type SimpleConfig struct {
-	IPAddr   string
-	PortAddr string
-}
+var _ Config = (*lockservice.SimpleConfig)(nil)
 
 // SimpleClient implements Client, the lockclient for LocKey.
 type SimpleClient struct {
-	config SimpleConfig
-}
-
-// IP returns the IP from SimpleConfig.
-func (scfg *SimpleConfig) IP() string {
-	return scfg.IPAddr
-}
-
-// Port returns the port from SimpleConfig.
-func (scfg *SimpleConfig) Port() string {
-	return scfg.PortAddr
+	config lockservice.SimpleConfig
 }
 
 var _ Client = (*SimpleClient)(nil)
@@ -38,7 +22,7 @@ var _ Client = (*SimpleClient)(nil)
 // Acquire makes a HTTP call to the lockserver and acquires the lock.
 // The errors invloved may be due the HTTP errors or the lockservice errors.
 func (sc *SimpleClient) Acquire(d lockservice.Descriptors) error {
-	endPoint := sc.config.IPAddr + ":" + sc.config.PortAddr + "/acquire"
+	endPoint := sc.config.IP() + ":" + sc.config.Port() + "/acquire"
 
 	testData := lockservice.LockRequest{FileID: d.ID()}
 	requestJson, err := json.Marshal(testData)

--- a/internal/lockclient/simple_client_test.go
+++ b/internal/lockclient/simple_client_test.go
@@ -15,7 +15,7 @@ func TestAcquireandRelease(t *testing.T) {
 	zerolog.New(os.Stdout).With()
 
 	log := zerolog.New(os.Stdout).With().Logger().Level(zerolog.GlobalLevel())
-	scfg := lockservice.NewSimpleConfig("127.0.0.1", "1234")
+	scfg := lockservice.NewSimpleConfig("http://127.0.0.1", "1234")
 	ls := lockservice.NewSimpleLockService(log)
 
 	quit := make(chan bool, 1)
@@ -33,7 +33,7 @@ func TestAcquireandRelease(t *testing.T) {
 	// Server takes some time to start
 	time.Sleep(100 * time.Millisecond)
 	t.Run("acquire 'test'", func(t *testing.T) {
-		sc := SimpleClient{config: SimpleConfig{IPAddr: "http://127.0.0.1", PortAddr: "1234"}}
+		sc := SimpleClient{config: *scfg}
 		d := lockservice.NewSimpleDescriptor("test")
 
 		got := sc.Acquire(d)
@@ -43,7 +43,7 @@ func TestAcquireandRelease(t *testing.T) {
 		}
 	})
 	t.Run("release 'test'", func(t *testing.T) {
-		sc := SimpleClient{config: SimpleConfig{IPAddr: "http://127.0.0.1", PortAddr: "1234"}}
+		sc := SimpleClient{config: *scfg}
 		d := lockservice.NewSimpleDescriptor("test")
 
 		got := sc.Release(d)

--- a/internal/node/simple_node.go
+++ b/internal/node/simple_node.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 func Start(ls *lockservice.SimpleLockService, scfg lockservice.SimpleConfig) error {
 
 	IP := scfg.IP()
+	IP = strings.TrimPrefix(IP, "http://")
 	port := scfg.Port()
 
 	if err := checkValidPort(port); err != nil {


### PR DESCRIPTION
`SimpleConfig` was redundantly defined in `lockclient` in addition to the definition `lockservice`.

The struct and associated functions have been removed from `lockclient`.
Additionally, the lockclient test has been refactorted to use `scfg`.

An issue I encountered while trying to use `scfg` in the tests was that, to make a POST request, the URL requires the prefix `http://`, however, the inclusion of this prefix while creating an instance of `http.server` in `node.Start()` was causing the test to fail.

I think, including the prefix in node.Start() causes it to behave differently, as on running the test, `Starting Server on http://127.0.0.1:1234` instead of `Starting Server on 127.0.0.1:1234` would be printed. 

To solve this issue, I have used the `strings.TrimPrefix()` function in `node.Start()`